### PR TITLE
fix(template): also gate .venv ignore on scripts=true

### DIFF
--- a/{{cookiecutter.project_slug}}/.prettierignore
+++ b/{{cookiecutter.project_slug}}/.prettierignore
@@ -1,6 +1,6 @@
 # Environment variables
 .env
-{%- if cookiecutter.with_python == 'true' %}
+{%- if cookiecutter.with_python == 'true' or cookiecutter.scripts == 'true' %}
 
 # Python Dependencies
 .venv/


### PR DESCRIPTION
Extends the generated `.prettierignore`'s venv/cache guard to also fire on `scripts='true'`. Without it, the `.scripts/` Poetry venv was exposed to `prettier --check .`, which broke once `pydantic-core` 2.46.3 started shipping an unformatted SBOM in dist-info.